### PR TITLE
Beat Baseline with GA

### DIFF
--- a/incremental_learning/optimize.py
+++ b/incremental_learning/optimize.py
@@ -72,12 +72,12 @@ def hyperparam_objective(trial):
     omega_base = trainer2.get_cf_metric('omega_base')
     omega_new = trainer2.get_cf_metric('omega_new')
     
-    objective = -(omega_base - omega_new)^2 - (1-omega_base)^2 - (1-omega_new)^2
-    return objective
+    objective = -(omega_base - omega_new)**2 - (1-omega_base)**2 - (1-omega_new)**2
+    return objective, omega_base, omega_new
 
 def opt_process():
     #hyperparameter optimization
-    study = optuna.create_study(study_name="ga6", storage="sqlite:///db.sqlite3", load_if_exists=True, direction="maximize")
+    study = optuna.create_study(study_name="ga7", storage="sqlite:///db.sqlite3", load_if_exists=True, directions=["maximize", "maximize", "maximize"])
     study.optimize(hyperparam_objective, n_trials=100)
 
     print("Best hyperparameters:")

--- a/incremental_learning/test.py
+++ b/incremental_learning/test.py
@@ -36,21 +36,20 @@ def main():
         'batch_size': 64,
         'num_epochs': 1,
         'lr': 0.001,
-        'train_val_ratio': 0.8,
-        'mutation_rate': 0.8,
-        'mutation_scale': 0.2,
-        'crossover_rate': 0.5,
+        'mutation_rate': 0.1,
+        'mutation_scale': 0.1,
+        'crossover_rate': 0.1,
         'selection_ratio': [0.5, 0.2, 0.2, 0.1],#children,mutants,elites,new
-        'num_generations': 10,
-        'initial_population_size': 10,
-        'recall_importance': 0.5,
+        'num_generations': 600,
+        'initial_population_size': 30,
+        'recall_importance': 0.4,
         'parent_selection_strategy': "combined",
-        'crossover_strategy': "importance" #none, random, importance
+        'crossover_strategy': "random" #none, random, importance
     }
     
     incremental_trainer_config = {
-        'replay_buffer_size': 300,
-        'incremental_training_size': 300,
+        'replay_buffer_size': 1000,
+        'incremental_training_size': 1000,
         'training_sessions': 6,
         'base_classes': [0,1,2,3,4],
         'incremental_classes_total': [5,6,7,8,9],


### PR DESCRIPTION
Metrics according to paper in README.

```
Baseline vs GA session metrics
Omega All [baseline,ga]: 0.7375446283674133, 0.7555925749643028
Omega Base [baseline,ga]: 1.0339337877312562, 0.8742979533555449
Omega New [baseline,ga]: 0.21000000000000002, 0.9765999999999998
```

```
incremental_trainer_config = {
        'replay_buffer_size': 1000,
        'incremental_training_size': 1000,
        'training_sessions': 6,
        'base_classes': [0,1,2,3,4],
        'incremental_classes_total': [5,6,7,8,9],
        'incremental_classes_per_session': 1
    }

hyperparameters_session = {
        'batch_size': 64,
        'num_epochs': 1,
        'lr': 0.001,
        'mutation_rate': 0.1,
        'mutation_scale': 0.1,
        'crossover_rate': 0.1,
        'selection_ratio': [0.5, 0.2, 0.2, 0.1],#children,mutants,elites,new
        'num_generations': 600,
        'initial_population_size': 30,
        'recall_importance': 0.4,
        'parent_selection_strategy': "combined",
        'crossover_strategy': "random" #none, random, importance
    }
```



**GA:**
<img width="543" alt="image" src="https://github.com/user-attachments/assets/9b9d21cf-6f2c-4e01-980f-d19245003778" />


**Baseline:**
<img width="534" alt="image" src="https://github.com/user-attachments/assets/fad01848-3701-4027-a78a-72885a5f73fd" />
